### PR TITLE
feat: implement preview functionality with scaling and snapping features across design components

### DIFF
--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -54,6 +54,7 @@ export default function Header() {
       background_image: "",
       components: [],
       project_id: newDesignId,
+      preview_url: ""
     };
 
     await createDesign(newDesignId, initialComponents);

--- a/src/components/dashboard/SizeInput.tsx
+++ b/src/components/dashboard/SizeInput.tsx
@@ -54,6 +54,7 @@ const SizeInput = ({
       background_image: "",
       components: [],
       project_id: newDesignId,
+      preview_url:""
     }
 
     await createDesign(newDesignId, initialComponents);

--- a/src/components/design/Circle.tsx
+++ b/src/components/design/Circle.tsx
@@ -1,6 +1,7 @@
 import { ElementComponent } from '@/types/Element.type';
 import React, { RefObject } from 'react'
 import ResizeButton from './ResizeButton';
+import { previewScale } from '@/utils/scale';
 
 const Circle = ({
     component,
@@ -10,7 +11,8 @@ const Circle = ({
     handleResize,
     handleRotate,
     isRotating,
-    rotate, 
+    rotate,
+    isPreview
 }: {
     component: ElementComponent,
     handleClickElement: (element: ElementComponent) => void,
@@ -20,6 +22,7 @@ const Circle = ({
     handleRotate: (e: React.MouseEvent) => void;
     isRotating: RefObject<boolean>;
     rotate: number;
+    isPreview?: boolean;
 }) => {
 
     return (
@@ -27,14 +30,17 @@ const Circle = ({
             onMouseDown={(e) => handleMouseDown(e, component)}
             key={component.id}
             id={`element-${component.id}`}
-            onClick={() => handleClickElement(component)}
+            onClick={() => {
+                if (isPreview) return
+                handleClickElement(component)
+            }}
             className={`absolute group hover:border-[2px] hover:border-indigo-400 ${isSelected ? 'border-[2px] border-indigo-500' : ''}`}
             style={{
-                width: component.width + "px",
-                height: component.height + "px",
+                width: isPreview ? component.width * previewScale : component.width + "px",
+                height: isPreview ? component.height * previewScale : component.height + "px",
                 zIndex: component.z_index,
-                top: component.top,
-                left: component.left,
+                top: isPreview ? component.top! * previewScale : component.top,
+                left: isPreview ? component.left! * previewScale : component.left,
                 transform: `rotate(${component.rotation || 0}deg)`,
                 transformOrigin: 'center',
             }}
@@ -52,7 +58,7 @@ const Circle = ({
                     Math.floor(rotate)}
             </p>}
             {/* Resize Handles */}
-            {isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
+            {!isPreview && isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
         </div>
     )
 }

--- a/src/components/design/DownloadContent.tsx
+++ b/src/components/design/DownloadContent.tsx
@@ -60,14 +60,14 @@ const DownloadComponent = ({ addImage }: {
   }) => void;
 }) => {
   const [layout, setLayout] = useState<
-    { url: string; width: number; span: string; height: number; isTemp?: boolean; id?:string }[][]
+    { url: string; width: number; span: string; height: number; isTemp?: boolean; id?: string }[][]
   >([]);
 
   const [isUploading, setUploading] = useState(false);
   const [isLoading, setLoading] = useState(false);
 
   const [images, setImages] = useState<
-    { url: string; width: number; height: number; isTemp: boolean; id?:string }[]
+    { url: string; width: number; height: number; isTemp: boolean; id?: string }[]
   >([]);
 
   const updateLayoutFromImages = (imageList: typeof images, blobUrl?: string) => {
@@ -101,7 +101,7 @@ const DownloadComponent = ({ addImage }: {
         const responseJSON = await fetch("/api/design/upload");
         const response = await responseJSON.json();
 
-        const imageList = response.data.map((img: { width: number; height: number; url: string; id:string }) => ({
+        const imageList = response.data.map((img: { width: number; height: number; url: string; id: string }) => ({
           ...img,
           isTemp: false,
         }));
@@ -156,7 +156,7 @@ const DownloadComponent = ({ addImage }: {
 
         const newDataJSON = await newData.json();
         const data = newDataJSON.data
-  
+
         // Hapus temp dan tambahkan final image
         const updatedImages = [
           ...images.filter((img) => img.url !== blobUrl),
@@ -173,7 +173,7 @@ const DownloadComponent = ({ addImage }: {
     }
   };
 
-  const handleDeleteImage = async(url:string, id:string) => {
+  const handleDeleteImage = async (url: string, id: string) => {
     try {
       const imageDeleted = images.filter((img) => img.id !== id);
       const grouped = groupImages(
@@ -235,12 +235,25 @@ const DownloadComponent = ({ addImage }: {
                   src={img.url}
                   onClick={() => {
                     if (img.isTemp) return;
+                    const width = img.width;
+                    const height = img.height;
+                    const maxWidth = 300;
+                    const maxHeight = 300;
+
+                    let newWidth = width;
+                    let newHeight = height;
+
+                    if (width > maxWidth || height > maxHeight) {
+                      const ratio = Math.min(maxWidth / width, maxHeight / height);
+                      newWidth = width * ratio;
+                      newHeight = height * ratio;
+                    }
                     addImage!({
                       blobUrl: img.url,
                       clientX: 10,
                       clientY: 10,
-                      newHeight: img.height / 2,
-                      newWidth: img.width / 2
+                      newHeight: newHeight,
+                      newWidth: newWidth
                     })
                   }}
                   className={`w-full h-[100px] rounded-md object-cover cursor-pointer`}
@@ -248,7 +261,7 @@ const DownloadComponent = ({ addImage }: {
                 />
 
                 <button onClick={() => handleDeleteImage(img.url, img.id || "")} className="absolute text-xs p-1 top-1 right-1 cursor-pointer bg-white rounded-sm hover:bg-gray-300">
-                  <FaTrash/>
+                  <FaTrash />
                 </button>
 
                 {img.isTemp && (

--- a/src/components/design/FeaturePanel.tsx
+++ b/src/components/design/FeaturePanel.tsx
@@ -61,7 +61,7 @@ const FeaturePanel = ({
     )
   }
   return (
-    <div className="absolute rounded-md shadow-md p-4 space-y-4 -top-20 bg-white z-50">
+    <div className="absolute rounded-md shadow-md p-4 space-y-4 -top-20 bg-white z-10">
       <div className="flex gap-4 items-center relative">
         {/* Color Picker */}
         <button

--- a/src/components/design/ImageElement.tsx
+++ b/src/components/design/ImageElement.tsx
@@ -1,6 +1,7 @@
 import { ElementComponent } from '@/types/Element.type';
 import React, { RefObject } from 'react'
 import ResizeButton from './ResizeButton';
+import { previewScale } from '@/utils/scale';
 
 const ImageElement = ({
     component,
@@ -11,6 +12,7 @@ const ImageElement = ({
     handleRotate,
     isRotating,
     rotate,
+    isPreview
 }: {
     component: ElementComponent,
     handleClickElement: (element: ElementComponent) => void,
@@ -20,22 +22,26 @@ const ImageElement = ({
     handleRotate: (e: React.MouseEvent) => void;
     isRotating: RefObject<boolean>;
     rotate: number;
+    isPreview?:boolean;
 }) => {
 
     return (
         <div
             onMouseDown={(e) => handleMouseDown(e, component)}
-            onClick={() => handleClickElement(component)}
+            onClick={() => {
+                if(isPreview) return;
+                handleClickElement(component)
+            }}
             key={component.id}
             id={`element-${component.id}`}
             className={`absolute hover:border-[2px] hover:border-indigo-400 ${isSelected ? "border-[2px] border-indigo-500" : ""
                 }`}
             style={{
-                width: component.width + "px",
-                height: component.height + "px",
+                width: isPreview ? component.width * previewScale : component.width + "px",
+                height: isPreview ? component.height * previewScale : component.height + "px",
                 zIndex: component.z_index,
-                top: component.top,
-                left: component.left,
+                top: isPreview ? component.top! * previewScale : component.top,
+                left: isPreview ? component.left! * previewScale : component.left,
                 cursor: "move",
                 transform: `rotate(${component.rotation || 0}deg)`,
                 transformOrigin: 'center',
@@ -55,7 +61,7 @@ const ImageElement = ({
                     Math.floor(rotate)}
             </p>}
             {/* Resize Handles */}
-            {isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
+            {!isPreview && isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
         </div>
     );
 }

--- a/src/components/design/Polygon.tsx
+++ b/src/components/design/Polygon.tsx
@@ -1,6 +1,7 @@
 import { ElementComponent } from '@/types/Element.type';
 import React, { RefObject } from 'react'
 import ResizeButton from './ResizeButton';
+import { previewScale } from '@/utils/scale';
 
 const Polygon = ({
     component,
@@ -11,6 +12,7 @@ const Polygon = ({
     handleRotate,
     isRotating,
     rotate,
+    isPreview
 }: {
     component: ElementComponent,
     handleClickElement: (element: ElementComponent) => void,
@@ -20,21 +22,25 @@ const Polygon = ({
     handleRotate: (e: React.MouseEvent) => void;
     isRotating: RefObject<boolean>;
     rotate: number;
+    isPreview?:boolean;
 }) => {
 
     return (
         <div
             onMouseDown={(e) => handleMouseDown(e, component)}
-            onClick={() => handleClickElement(component)}
+            onClick={() => {
+                if(isPreview) return;
+                handleClickElement(component)
+            }}
             id={`element-${component.id}`}
             key={component.id}
             className={`absolute group hover:border-[2px] hover:border-indigo-400 ${isSelected ? 'border-[2px] border-indigo-500' : ''}`}
             style={{
-                width: component.width + "px",
-                height: component.height + "px",
+                width: isPreview ? component.width * previewScale : component.width + "px",
+                height: isPreview ? component.height * previewScale : component.height + "px",
                 zIndex: component.z_index,
-                top: component.top,
-                left: component.left,
+                top: isPreview ? component.top! * previewScale : component.top,
+                left: isPreview ? component.left! * previewScale : component.left,
                 transform: `rotate(${component.rotation || 0}deg)`,
                 transformOrigin: 'center',
             }}
@@ -53,7 +59,7 @@ const Polygon = ({
                     Math.floor(rotate)}
             </p>}
             {/* Resize Handles */}
-            {isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
+            {!isPreview && isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
         </div>
     )
 }

--- a/src/components/design/Rect.tsx
+++ b/src/components/design/Rect.tsx
@@ -1,6 +1,7 @@
 import { ElementComponent } from '@/types/Element.type';
 import React, { RefObject } from 'react'
 import ResizeButton from './ResizeButton';
+import { previewScale } from '@/utils/scale';
 
 const Rect = ({
     component,
@@ -11,6 +12,7 @@ const Rect = ({
     handleRotate,
     isRotating,
     rotate,
+    isPreview
 }: {
     component: ElementComponent,
     handleClickElement: (element: ElementComponent) => void,
@@ -20,23 +22,27 @@ const Rect = ({
     handleRotate: (e: React.MouseEvent) => void;
     isRotating: RefObject<boolean>;
     rotate: number;
+    isPreview?: boolean;
 }) => {
 
     return (
         <div
             onMouseDown={(e) => handleMouseDown(e, component)}
-            onClick={() => handleClickElement(component)}
+            onClick={() => {
+                if (isPreview) return
+                handleClickElement(component)
+            }}
             key={component.id}
             id={`element-${component.id}`}
             className={`absolute hover:border-[2px] hover:border-indigo-400 ${isSelected ? "border-[2px] border-indigo-500" : ""
                 }`}
             style={{
-                width: component.width + "px",
-                height: component.height + "px",
-                background: component.color,
+                width: isPreview ? component.width * previewScale : component.width + "px",
+                height: isPreview ? component.height * previewScale : component.height + "px",
                 zIndex: component.z_index,
-                top: component.top || 10,
-                left: component.left || 10,
+                top: isPreview ? component.top! * previewScale : component.top,
+                left: isPreview ? component.left! * previewScale : component.left,
+                background: component.color,
                 cursor: "move",
                 transform: `rotate(${component.rotation || 0}deg)`,
                 transformOrigin: 'center',
@@ -49,7 +55,7 @@ const Rect = ({
                     Math.floor(rotate)}
             </p>}
             {/* Resize Handles */}
-            {isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
+            {!isPreview && isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
         </div>
     );
 }

--- a/src/components/design/Text.tsx
+++ b/src/components/design/Text.tsx
@@ -1,6 +1,7 @@
 import { ElementComponent } from '@/types/Element.type';
 import React, { RefObject, useEffect, useRef, useState } from 'react'
 import ResizeButton from './ResizeButton';
+import { previewScale } from '@/utils/scale';
 
 const Text = ({
     component,
@@ -13,6 +14,7 @@ const Text = ({
     rotate,
     updateTextValue,
     handleIsTyping,
+    isPreview
 }: {
     component: ElementComponent,
     handleClickElement: (element: ElementComponent) => void,
@@ -24,6 +26,7 @@ const Text = ({
     rotate: number;
     updateTextValue: (id: number, value: string) => void;
     handleIsTyping: () => void;
+    isPreview?:boolean;
 }) => {
     const isGradient = component.color?.includes("linear-gradient");
     const [isEditing, setIsEditing] = useState(false);
@@ -44,7 +47,10 @@ const Text = ({
             onMouseDown={(e) => {
                 if (!isEditing) handleMouseDown(e, component);
             }}
-            onClick={() => handleClickElement(component)}
+            onClick={() => {
+                if(isPreview) return;
+                handleClickElement(component)
+            }}
             onDoubleClick={() => {
                 setIsEditing(true)
                 handleIsTyping()
@@ -53,14 +59,15 @@ const Text = ({
             id={`element-${component.id}`}
             className={`absolute flex items-center cursor-pointer ${isSelected ? 'border-2 border-indigo-500' : ''}`}
             style={{
-                top: component.top,
-                left: component.left,
-                width: component.width,
+                width: isPreview ? component.width * previewScale : component.width + "px",
+                // height: isPreview ? component.height * previewScale : component.height + "px",
+                zIndex: component.z_index,
+                top: isPreview ? component.top! * previewScale : component.top,
+                left: isPreview ? component.left! * previewScale : component.left,
                 height: "auto",
                 transform: `rotate(${rotate}deg)`,
-                zIndex: component.z_index,
                 fontFamily: component.font_family,
-                fontSize: component.font_size,
+                fontSize: isPreview ? component.font_size! * previewScale : component.font_size,
                 backgroundImage: isGradient ? component.color : undefined,
                 WebkitBackgroundClip: isGradient ? "text" : undefined,
                 WebkitTextFillColor: isGradient ? "transparent" : undefined,
@@ -120,7 +127,7 @@ const Text = ({
                 </p>
             )}
             {/* Resize Handles */}
-            {isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
+            {!isPreview && isSelected && <ResizeButton handleResize={handleResize} handleRotate={handleRotate} />}
         </div>
     );
 }

--- a/src/types/CanvasType.ts
+++ b/src/types/CanvasType.ts
@@ -8,4 +8,5 @@ export type CanvasType = {
     components: ElementComponent[];
     background_color: string;
     background_image: string;
+    preview_url:string;
 }

--- a/src/utils/scale.ts
+++ b/src/utils/scale.ts
@@ -1,0 +1,5 @@
+const previewScale = 0.245;
+
+export {
+    previewScale,
+}


### PR DESCRIPTION
## Description
Pull Request ini memperkenalkan fungsionalitas mode pratinjau baru untuk kanvas desain, memungkinkan rendering desain yang diskalakan dan non-interaktif. Ini juga meningkatkan pengalaman pengguna dengan menambahkan fitur penempatan cerdas untuk elemen di kanvas dan menerapkan penskalaan yang lebih baik untuk gambar yang diunggah. Penyesuaian indeks-z kecil untuk panel fitur juga disertakan.

## Link Issue
- N/A

## Changes Made
- Mengimplementasikan mode pratinjau dengan skala global dan properti "isPreview" di seluruh komponen elemen kanvas (lingkaran, persegi panjang, teks, poligon, gambar), memungkinkan rendering desain yang diskalakan dan non-interaktif.
- Menambahkan fungsionalitas penempatan elemen ke kanvas, memfasilitasi penyejajaran komponen ke tepi dan garis tengah kanvas.
- Menyesuaikan logika impor gambar untuk secara otomatis menskalakan gambar besar (>300px) saat ditambahkan ke kanvas.
- Memperbarui indeks-z panel fitur untuk mencegah masalah lapisan potensial.
- Menambahkan bidang "preview_url" ke tipe "CanvasType" untuk penyimpanan URL pratinjau di masa mendatang.
- Menyesuaikan logika "drag n drop" gambar untuk memposisikan gambar baru di tengah kursor.

## Testing
- Verifikasi bahwa elemen (Persegi Panjang, Lingkaran, Teks, Poligon, Gambar) dapat dipindahkan, diubah ukurannya, dan diputar dengan benar pada kanvas utama.
- Uji perilaku penempatan baru: seret elemen di dekat tepi dan garis tengah kanvas untuk mengamati penempatannya.
- Unggah gambar besar (>300px dalam lebar/tinggi) dan verifikasi gambar tersebut diskalakan saat ditambahkan ke kanvas.
- Konfirmasikan sifat non-interaktif dan penskalaan yang benar dari instance kanvas pratinjau yang baru (kanvas kedua di DesignModules).
- Pastikan FeaturePanel tetap dapat diakses dan terlihat saat elemen dipilih.
- Buat desain baru dan verifikasi bahwa status awal menyertakan "preview_url".
